### PR TITLE
Fix adjust_transition_matrix_size typo

### DIFF
--- a/main_comparision.py
+++ b/main_comparision.py
@@ -127,7 +127,7 @@ def load_data():
         tgt_val = torch.stack([sample_markov(config.len_seqs, T)for _ in range(5000)]).to("cpu")
 
         config.vocab_size = vc_sz
-        S, T = addjust_transition_matrix_size(S, T)
+        S, T = adjust_transition_matrix_size(S, T)
         return src, tgt, {"S": S, "T": T, "src_val": src_val, "tgt_val": tgt_val}
 
     # ----------------------- gaussian -----------------------

--- a/utils.py
+++ b/utils.py
@@ -276,10 +276,8 @@ def seed_everything(seed: int = 0, deterministic: bool = False) -> None:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
 
-def addjust_transition_matrix_size(S, T):
-    """
-    Adjust the size of the transition matrix to include extra target tokens.
-    """
+def adjust_transition_matrix_size(S, T):
+    """Adjust the size of the transition matrix to include extra target tokens."""
     if S.shape[0] == T.shape[0]:
         return S, T
     if S.shape[0] < T.shape[0]:


### PR DESCRIPTION
## Summary
- rename `addjust_transition_matrix_size` to `adjust_transition_matrix_size`
- update call sites in `main_comparision.py`

## Testing
- `python -m py_compile main.py main2.py main_comparision.py data.py diffusion.py models.py plot_function.py training.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684b22935634832fbe2c70b574f0dd54